### PR TITLE
feat: add raw keyboard injection path

### DIFF
--- a/src/lib/platform/MSWindowsRawInputInjector.cpp
+++ b/src/lib/platform/MSWindowsRawInputInjector.cpp
@@ -30,12 +30,23 @@ typedef struct _MOUSE_INPUT_DATA
   ULONG ExtraInformation;
 } MOUSE_INPUT_DATA, *PMOUSE_INPUT_DATA;
 
+typedef struct _KEYBOARD_INPUT_DATA
+{
+  USHORT UnitId;
+  USHORT MakeCode;
+  USHORT Flags;
+  USHORT Reserved;
+  ULONG ExtraInformation;
+} KEYBOARD_INPUT_DATA, *PKEYBOARD_INPUT_DATA;
+
 namespace {
 
 using NtUserInjectMouseInputFn = LONG(WINAPI *)(ULONG, PMOUSE_INPUT_DATA, ULONG);
+using NtUserInjectKeyboardInputFn = LONG(WINAPI *)(ULONG, PKEYBOARD_INPUT_DATA, ULONG);
 
 struct RawInjector {
   NtUserInjectMouseInputFn injectMouse = nullptr;
+  NtUserInjectKeyboardInputFn injectKeyboard = nullptr;
   bool initialized = false;
 };
 
@@ -51,6 +62,8 @@ void initInjector()
   if (HMODULE lib = LoadLibraryW(L"win32u.dll")) {
     g_injector.injectMouse = reinterpret_cast<NtUserInjectMouseInputFn>(
         GetProcAddress(lib, "NtUserInjectMouseInput"));
+    g_injector.injectKeyboard = reinterpret_cast<NtUserInjectKeyboardInputFn>(
+        GetProcAddress(lib, "NtUserInjectKeyboardInput"));
   }
 }
 
@@ -70,6 +83,37 @@ bool sendMouseRelativeRawInput(int dx, int dy)
   data.UnitId = 0;
   data.Flags = 0; // relative move
   LONG status = g_injector.injectMouse(1, &data, sizeof(data));
+  return status >= 0;
+}
+
+bool sendKeyboardRawInput(WORD vk, WORD scan, DWORD flags)
+{
+  (void)vk;
+  initInjector();
+  if (g_injector.injectKeyboard == nullptr) {
+    return false;
+  }
+
+  // The raw input path expects scancodes; fall back if unicode events are
+  // requested.
+  if ((flags & KEYEVENTF_UNICODE) != 0) {
+    return false;
+  }
+
+  KEYBOARD_INPUT_DATA data{};
+  data.UnitId = 0;
+  data.MakeCode = scan;
+  data.Flags = 0;
+  if (flags & KEYEVENTF_KEYUP) {
+    data.Flags |= 0x1; // KEY_BREAK
+  }
+  if (flags & KEYEVENTF_EXTENDEDKEY) {
+    data.Flags |= 0x2; // KEY_E0
+  }
+  data.Reserved = 0;
+  data.ExtraInformation = 0;
+
+  LONG status = g_injector.injectKeyboard(1, &data, sizeof(data));
   return status >= 0;
 }
 

--- a/src/lib/platform/MSWindowsRawInputInjector.h
+++ b/src/lib/platform/MSWindowsRawInputInjector.h
@@ -12,5 +12,9 @@
 //! Returns true if the injection succeeds.
 bool sendMouseRelativeRawInput(int dx, int dy);
 
+//! Attempt to inject a keyboard event using the raw input path.
+//! Returns true if the injection succeeds.
+bool sendKeyboardRawInput(WORD vk, WORD scan, DWORD flags);
+
 #endif
 


### PR DESCRIPTION
## Summary
- support raw keyboard injection via `NtUserInjectKeyboardInput`
- add `sendKeyInterception` with raw input, Interception driver, and SendInput fallbacks
- route fake key events through new keyboard injection logic

## Testing
- `cmake -S . -B build -DHAVE_Xtst=1` *(fails: Could not find a package configuration file provided by "Qt6" ...)*

------
https://chatgpt.com/codex/tasks/task_e_68946e2db30483329c3157bad8fe0955