### PR TITLE
fix: prevent incorrect US fallback when keyboard layout unavailable

### DIFF
--- a/src/lib/deskflow/unix/DeskflowXkbKeyboard.cpp
+++ b/src/lib/deskflow/unix/DeskflowXkbKeyboard.cpp
@@ -29,7 +29,7 @@ DeskflowXkbKeyboard::DeskflowXkbKeyboard()
 
 const char *DeskflowXkbKeyboard::getLayout() const
 {
-  return m_data.layout ? m_data.layout : "us";
+  return m_data.layout ? m_data.layout : "";
 }
 
 const char *DeskflowXkbKeyboard::getVariant() const


### PR DESCRIPTION
## Summary
- avoid defaulting to "us" when XKB layout info cannot be read

## Testing
- `cmake -S . -B build` *(fails: VERSION "1.23.0.943f52c4" format invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68990208531c83329300413c94ee4f7a