### PR TITLE
fix: remove unicode text injection

### DIFF
--- a/src/lib/platform/MSWindowsDesks.h
+++ b/src/lib/platform/MSWindowsDesks.h
@@ -156,12 +156,6 @@ public:
   */
   void fakeKeyChord(WORD virtualKey, const std::vector<WORD> &modifiers) const;
 
-  //! Fake Unicode text input
-  /*!
-  Types the given text using Unicode events.
-  */
-  void fakeUnicodeText(const std::wstring &text) const;
-
   //! Fake mouse press/release
   /*!
   Synthesize a press or release of mouse button \c id.

--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -1201,9 +1201,13 @@ void MSWindowsKeyState::fakeKey(const Keystroke &keystroke)
     // get the virtual key for the button
     WORD vk = (WORD)keystroke.m_data.m_button.m_client;
 
-    if (vk == 0 && keystroke.m_data.m_button.m_press) {
-      std::wstring text(1, static_cast<wchar_t>(scanCode & 0xFFu));
-      m_desks->fakeUnicodeText(text);
+    if (vk == 0) {
+      DWORD flags = KEYEVENTF_SCANCODE;
+      if (!keystroke.m_data.m_button.m_press)
+        flags |= KEYEVENTF_KEYUP;
+      if (scanCode & 0x100)
+        flags |= KEYEVENTF_EXTENDEDKEY;
+      m_desks->fakeKeyEvent(vk, scanCode, flags, keystroke.m_data.m_button.m_repeat);
       break;
     }
 


### PR DESCRIPTION
## Summary
- drop unused Unicode text injection helpers
- send scancode-based events when virtual key is missing
- simplify keyboard injection to avoid Unicode path

## Testing
- `cmake -S . -B build` *(fails: VERSION "1.23.0.1b076843" format invalid)*

------
https://chatgpt.com/codex/tasks/task_e_689909f8e8588332b826e45044d34cd4