### PR TITLE
Log GetLastError when GetRawInputData fails

### DIFF
--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -245,11 +245,13 @@ void handle_raw_input(HRAWINPUT hraw)
 {
   UINT size = 0;
   if (GetRawInputData(hraw, RID_INPUT, nullptr, &size, sizeof(RAWINPUTHEADER)) != 0) {
+    LOG_WARN("GetRawInputData size query failed, err=%lu", GetLastError());
     return;
   }
 
   std::vector<uint8_t> data(size);
   if (GetRawInputData(hraw, RID_INPUT, data.data(), &size, sizeof(RAWINPUTHEADER)) != size) {
+    LOG_WARN("GetRawInputData data retrieval failed, err=%lu", GetLastError());
     return;
   }
 


### PR DESCRIPTION
## Summary
- add warnings with GetLastError when GetRawInputData queries fail in handle_raw_input

## Testing
- `cmake -S . -B build` *(fails: VERSION "1.23.0.288f134f" format invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68993e10919c8332930022d1f0a1460e