### PR TITLE
Avoid feedback loops from synthetic raw input

### DIFF
--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -256,6 +256,13 @@ void handle_raw_input(HRAWINPUT hraw)
   }
 
   RAWINPUT *raw = reinterpret_cast<RAWINPUT *>(data.data());
+  // Raw input generated via SendInput has no originating device. Ignore such
+  // events so that synthesised input does not get captured and re-injected,
+  // which would otherwise create a feedback loop.
+  if (raw->header.hDevice == nullptr) {
+    return;
+  }
+
   std::vector<INPUT> inputs;
 
   if (raw->header.dwType == RIM_TYPEMOUSE) {


### PR DESCRIPTION
## Summary
- Ignore raw input events without a device handle to prevent reinjecting synthetic SendInput events

## Testing
- `cmake -S . -B build` *(fails: Could not find a configuration file for package "Qt6" that is compatible with requested version "6.7.0"; found 6.4.2)*

------
https://chatgpt.com/codex/tasks/task_e_689947c521d483329c2feb2cbc86867a