### PR TITLE
Remove chord key injection to prevent duplicate inputs

### DIFF
--- a/src/lib/platform/MSWindowsDesks.h
+++ b/src/lib/platform/MSWindowsDesks.h
@@ -15,7 +15,6 @@
 
 #include <map>
 #include <string>
-#include <vector>
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
@@ -149,12 +148,6 @@ public:
   Synthesize a press or release of key \c button.
   */
   void fakeKeyEvent(WORD virtualKey, WORD scanCode, DWORD flags, bool isAutoRepeat) const;
-
-  //! Fake key with modifiers
-  /*!
-  Sends a key press and release with the given modifier virtual keys applied.
-  */
-  void fakeKeyChord(WORD virtualKey, const std::vector<WORD> &modifiers) const;
 
   //! Fake mouse press/release
   /*!

--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -14,7 +14,6 @@
 #include "platform/MSWindowsDesks.h"
 #include "platform/MSWindowsHandle.h"
 #include <string>
-#include <vector>
 
 // extended mouse buttons
 #if !defined(VK_XBUTTON1)
@@ -1208,23 +1207,6 @@ void MSWindowsKeyState::fakeKey(const Keystroke &keystroke)
       if (scanCode & 0x100)
         flags |= KEYEVENTF_EXTENDEDKEY;
       m_desks->fakeKeyEvent(vk, scanCode, flags, keystroke.m_data.m_button.m_repeat);
-      break;
-    }
-
-    if (!is_modifier_vk(vk) && vk != VK_SNAPSHOT) {
-      if (keystroke.m_data.m_button.m_press) {
-        std::vector<WORD> mods;
-        KeyModifierMask mask = getActiveModifiers();
-        if ((mask & KeyModifierShift) != 0)
-          mods.push_back(VK_SHIFT);
-        if ((mask & KeyModifierControl) != 0)
-          mods.push_back(VK_CONTROL);
-        if ((mask & KeyModifierAlt) != 0)
-          mods.push_back(VK_MENU);
-        if ((mask & KeyModifierSuper) != 0)
-          mods.push_back(VK_LWIN);
-        m_desks->fakeKeyChord(vk, mods);
-      }
       break;
     }
 


### PR DESCRIPTION
## Summary
- drop the Windows-specific key chord injection path that produced duplicate keystrokes
- rely on standard `fakeKeyEvent` handling for all keys

## Testing
- `cmake -S . -B build -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON` *(fails: Missing library Xtst)*

------
https://chatgpt.com/codex/tasks/task_e_68994f8f4b508332ade3a0c8da692563