### PR TITLE
Avoid raw input duplication on Windows

### DIFF
--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -570,11 +570,11 @@ HWND MSWindowsDesks::createWindow(ATOM windowClass, const char *name) const
   RAWINPUTDEVICE devices[2] = {};
   devices[0].usUsagePage = HID_USAGE_PAGE_GENERIC;
   devices[0].usUsage = HID_USAGE_GENERIC_MOUSE;
-  devices[0].dwFlags = RIDEV_INPUTSINK;
+  devices[0].dwFlags = RIDEV_INPUTSINK | RIDEV_NOLEGACY;
   devices[0].hwndTarget = window;
   devices[1].usUsagePage = HID_USAGE_PAGE_GENERIC;
   devices[1].usUsage = HID_USAGE_GENERIC_KEYBOARD;
-  devices[1].dwFlags = RIDEV_INPUTSINK;
+  devices[1].dwFlags = RIDEV_INPUTSINK | RIDEV_NOLEGACY;
   devices[1].hwndTarget = window;
   if (RegisterRawInputDevices(devices, 2, sizeof(RAWINPUTDEVICE)) == FALSE) {
     LOG_WARN("RegisterRawInputDevices failed: %lu", GetLastError());


### PR DESCRIPTION
## Summary
- avoid duplicated keyboard/mouse events by suppressing legacy input when registering raw devices

## Testing
- `cmake -S . -B build` *(fails: VERSION "1.23.0.ae04f5d3" format invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6899a38b9c1883329033b7ef1d5e80d0